### PR TITLE
Address additional issues in conversion to pySBOL2

### DIFF
--- a/doebase/synbioParts.py
+++ b/doebase/synbioParts.py
@@ -153,7 +153,7 @@ def _defineParts(doc,parts,getSequences=True,backtranslate=True,codontable='Eeco
         for com in locdoc.componentDefinitions:
             if com.name is None:
                 com.name = com.displayId
-        locdoc.copy('http://liverpool.ac.uk',doc)
+        locdoc.copy(target_doc=doc)
         
     for i in parts.index:
         name = parts.loc[i,'Name']
@@ -188,7 +188,7 @@ def _defineParts(doc,parts,getSequences=True,backtranslate=True,codontable='Eeco
                 else:
                     terminator = sbol.ComponentDefinition(name)                    
                 terminator.roles = sboldef[ptype]
-                terminator.setPropertyValue('http://purl.org/dc/terms/description',part)
+                terminator.description = part
                 try:
                     if part not in doc.componentDefinitions:
                         terminator = doc.getComponentDefinition(part)
@@ -204,7 +204,7 @@ def _defineParts(doc,parts,getSequences=True,backtranslate=True,codontable='Eeco
                 else:
                         origin = sbol.ComponentDefinition(name)                    
                 origin.roles = sboldef[ptype]
-                origin.setPropertyValue('http://purl.org/dc/terms/description',part)
+                origin.description = part
                 origin.name = name
                 try:
                     if part not in doc.componentDefinitions:

--- a/doebase/synbioParts.py
+++ b/doebase/synbioParts.py
@@ -154,6 +154,8 @@ def _defineParts(doc,parts,getSequences=True,backtranslate=True,codontable='Eeco
             if com.name is None:
                 com.name = com.displayId
         locdoc.copy(target_doc=doc)
+    # This is a dangerous assumption, and will cause incorrect behavior when the parts supplied are not in this homespace
+    sbol.setHomespace('http://liverpool.ac.uk/')
         
     for i in parts.index:
         name = parts.loc[i,'Name']
@@ -171,7 +173,7 @@ def _defineParts(doc,parts,getSequences=True,backtranslate=True,codontable='Eeco
                 else:
                     promoter = sbol.ComponentDefinition(name)                    
                 promoter.roles = sboldef[ptype]
-                promoter.setPropertyValue('http://purl.org/dc/terms/description',part)
+                promoter.description = part
                 try:
                     if part not in doc.componentDefinitions:
                         promoter = doc.getComponentDefinition(part)
@@ -300,7 +302,7 @@ def _definePartsOld(doc,parts):
             if ptype == 'promoter':
                 promoter = sbol.ComponentDefinition(name)
                 promoter.roles = sboldef[ptype]
-                promoter.setPropertyValue('http://purl.org/dc/terms/description',part)
+                promoter.description = part
                 doc.addComponentDefinition(promoter)
                 try:
                     terminator = sbol.ComponentDefinition('Ter')
@@ -311,12 +313,12 @@ def _definePartsOld(doc,parts):
             elif ptype == 'origin':
                 origin = sbol.ComponentDefinition(name)
                 origin.roles = sboldef[ptype]
-                origin.setPropertyValue('http://purl.org/dc/terms/description',part)
+                origin.description = part
                 doc.addComponentDefinition(origin)
             elif ptype == 'gene' or ptype == 'resistance':
                 origin = sbol.ComponentDefinition(name)
                 origin.roles = sboldef[ptype]
-                origin.setPropertyValue('http://purl.org/dc/terms/description',part)
+                origin.description = part
                 doc.addComponentDefinition(origin)
     return doc
 


### PR DESCRIPTION
The document copy operation is remapping items to their own namespace.
This doesn't appear to be necessary and unearthed a pySBOL2 bug (https://github.com/SynBioDex/pySBOL2/issues/413). 

I have also flagged an issue where there is an assumption about namespace hard-wired into the code which causes problems when it is not satisfied.

Cleaned up a few more abstraction breaks I came across as well.

(more work to address #1)